### PR TITLE
Support mis-extension-ed JPEGs, skip mis-extension-ed files for exiftool 

### DIFF
--- a/lib/date_extractors/exif_extractor.dart
+++ b/lib/date_extractors/exif_extractor.dart
@@ -27,8 +27,8 @@ Future<DateTime?> exifDateTimeExtractor(final File file) async {
   // 1. If the mimeType is supported by exif_reader, we use the exif_reader library to read exif. If that fails, exiftool is still used as a fallback, cause it's worth a try.
   // 2. If the mimeType is not supported by exif_reader or null, we try exiftool and don't even attempt exif_reader, because it would be pointless.
 
-  //We only read the first 4096 bytes as that's sufficient for MIME type detection
-  final List<int> headerBytes = await File(file.path).openRead(0, 4096).first;
+  //We only read the first 128 bytes as that's sufficient for MIME type detection
+  final List<int> headerBytes = await File(file.path).openRead(0, 128).first;
 
   //Getting mimeType.
   final String? mimeType = lookupMimeType(file.path, headerBytes: headerBytes);

--- a/lib/exif_writer.dart
+++ b/lib/exif_writer.dart
@@ -29,7 +29,7 @@ Future<bool> writeDateTimeToExif(
 
     if (mimeTypeFromExtension != mimeTypeFromHeader) {
       log(
-          "DateWriter - Extension is wrong, mimeType is '$mimeTypeFromHeader'. Exiftool would fail, thus skipping.                    \n ${file.path}",
+          "DateWriter - File has a wrong extension indicating '$mimeTypeFromExtension' but actually it is '$mimeTypeFromHeader'. Exiftool would fail, skipping.\n ${file.path}",
           level: 'error',
           forcePrint: true
       );
@@ -77,9 +77,11 @@ Future<bool> writeGpsToExif(
     }
 
     if (mimeTypeFromExtension != mimeTypeFromHeader) {
-      log("GPSWriter - Extension is wrong, mimeType is '$mimeTypeFromHeader'. Exiftool would fail, thus skipping.                     \n ${file.path}",
-      level: 'error',
-      forcePrint: true);
+      log(
+          "GPSWriter - File has a wrong extension indicating '$mimeTypeFromExtension' but actually it is '$mimeTypeFromHeader'. Exiftool would fail, skipping.\n ${file.path}",
+          level: 'error',
+          forcePrint: true
+      );
       return false;
     }
 

--- a/lib/exif_writer.dart
+++ b/lib/exif_writer.dart
@@ -128,7 +128,7 @@ Future<bool> _noExifToolDateTimeWriter(final File file, final DateTime dateTime,
     if (mimeTypeFromHeader != mimeTypeFromExtension) {
       log(
         "File has a wrong extension indicating '$mimeTypeFromExtension'"
-            " but actually it is '$mimeTypeFromHeader'. Will use native JPEG writer.\n ${file.path}",
+            " but actually it is '$mimeTypeFromHeader'. Will use native JPEG writer.     \n ${file.path}",
         level: 'warning',
         forcePrint: true
       );
@@ -178,8 +178,9 @@ Future<bool> _noExifGPSWriter(final File file, final DMSCoordinates coordinates,
     if (mimeTypeFromHeader != mimeTypeFromExtension) {
       log(
         "File has a wrong extension corresponding to '$mimeTypeFromExtension'"
-            " but actually it is '$mimeTypeFromHeader'. Will use native JPEG writer.",
-        level: 'warning'
+            " but actually it is '$mimeTypeFromHeader'. Will use native JPEG writer.     \n ${file.path}",
+        level: 'warning',
+        forcePrint: true
       );
     }
     //when it's a jpg and the image library can handle it

--- a/lib/exif_writer.dart
+++ b/lib/exif_writer.dart
@@ -127,8 +127,8 @@ Future<bool> _noExifToolDateTimeWriter(final File file, final DateTime dateTime,
   if (mimeTypeFromHeader == 'image/jpeg') {
     if (mimeTypeFromHeader != mimeTypeFromExtension) {
       log(
-        "File has a wrong extension indicating '$mimeTypeFromExtension'"
-            " but actually it is '$mimeTypeFromHeader'. Will use native JPEG writer.     \n ${file.path}",
+        "DateWriter - File has a wrong extension indicating '$mimeTypeFromExtension'"
+            " but actually it is '$mimeTypeFromHeader'. Will use native JPEG writer.\n ${file.path}",
         level: 'warning',
         forcePrint: true
       );
@@ -177,8 +177,8 @@ Future<bool> _noExifGPSWriter(final File file, final DMSCoordinates coordinates,
     final String? mimeTypeFromExtension = lookupMimeType(file.path);
     if (mimeTypeFromHeader != mimeTypeFromExtension) {
       log(
-        "File has a wrong extension corresponding to '$mimeTypeFromExtension'"
-            " but actually it is '$mimeTypeFromHeader'. Will use native JPEG writer.     \n ${file.path}",
+        "GPSWriter - File has a wrong extension indicating '$mimeTypeFromExtension'"
+            " but actually it is '$mimeTypeFromHeader'. Will use native JPEG writer. \n ${file.path}",
         level: 'warning',
         forcePrint: true
       );

--- a/lib/exif_writer.dart
+++ b/lib/exif_writer.dart
@@ -131,8 +131,7 @@ Future<bool> _noExifToolDateTimeWriter(final File file, final DateTime dateTime,
       log(
         "DateWriter - File has a wrong extension indicating '$mimeTypeFromExtension'"
             " but actually it is '$mimeTypeFromHeader'. Will use native JPEG writer.\n ${file.path}",
-        level: 'warning',
-        forcePrint: true
+        level: 'warning'
       );
     }
     //when it's a jpg and the image library can handle it
@@ -181,8 +180,7 @@ Future<bool> _noExifGPSWriter(final File file, final DMSCoordinates coordinates,
       log(
         "GPSWriter - File has a wrong extension indicating '$mimeTypeFromExtension'"
             " but actually it is '$mimeTypeFromHeader'. Will use native JPEG writer. \n ${file.path}",
-        level: 'warning',
-        forcePrint: true
+        level: 'warning'
       );
     }
     //when it's a jpg and the image library can handle it


### PR DESCRIPTION
High level overview:
1. if a file is actually jpeg but with wrong extension:
    use native methods, display a warning
      EDIT: warn only with `-v`
2. if a file is not actually a jpeg, and has a wrong extention:
    display an error, skip processing - exiftool will fail either way so don't waste time for that.

I might still refactor this, but I want you to take a look. :)

Additionally we need only 96 bytes for header MIME detection. (https://github.com/dart-lang/tools/blob/main/pkgs/mime/lib/src/magic_number.dart has at most 12 HEX values (each has 2 digits) for the header matching -> `12*2*4=96`). I've used 128 just in case some future MIME types would require more.