### PR TITLE
Fix - added number option back in interactive mode

### DIFF
--- a/lib/domain/services/user_interaction/user_interaction_service.dart
+++ b/lib/domain/services/user_interaction/user_interaction_service.dart
@@ -242,11 +242,13 @@ class ConsolidatedInteractiveService with LoggerMixin {
       switch (input) {
         case 'y':
         case 'yes':
+        case '2':
           await _presenter.showUserSelection(input, 'yes, limit file sizes');
           return true;
         case 'n':
         case 'no':
         case '':
+        case '1':
           await _presenter.showUserSelection(
             input,
             'no, don\'t limit file sizes',


### PR DESCRIPTION
Found a bug that number options does not work in interactive mode when configuring limitation of the maximum file size.

<img width="1913" height="234" alt="image" src="https://github.com/user-attachments/assets/ba0dfac7-a071-474c-81bd-0fafd9d814ff" />

Fixed by adding proper case in the function.